### PR TITLE
First-pass Port to ES6 + rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/dist
 /node_modules

--- a/heimdall.js
+++ b/heimdall.js
@@ -1,2 +1,0 @@
-var Heimdall = require('./lib/heimdall');;
-module.exports = Heimdall;

--- a/index.config.js
+++ b/index.config.js
@@ -1,0 +1,19 @@
+import nodeResolve from 'rollup-plugin-node-resolve';
+import buble from 'rollup-plugin-buble';
+import commonjs from 'rollup-plugin-commonjs';
+
+export default {
+  entry: 'index.js',
+  moduleName: 'heimdall',
+  format: 'iife',
+  plugins: [
+    buble(),
+    nodeResolve({ jsnext: true, main: true }),
+    commonjs({ include: 'node_modules/**' })
+  ],
+  targets: [
+    { dest: 'dist/bundle.cjs.js', format: 'cjs' },
+    { dest: 'dist/bundle.umd.js', format: 'umd' },
+    { dest: 'dist/bundle.es.js', format: 'es' },
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+<script src="dist/bundle.umd.js"></script>

--- a/index.js
+++ b/index.js
@@ -1,19 +1,22 @@
 'use strict';
+import Heimdall, { VERSION } from './lib/heimdall';
+// import semver from 'semver';
 
-var Heimdall = require('./lib/heimdall');
-var semver = require('semver');
-var version = require('./package.json').version;
-var compatibleVersion = '^' + version;
+let compatibleVersion = '^' + VERSION;
+let heimdall;
 
-
-if (process._heimdall) {
-  var globalVersion = process._heimdall.version;
-  if (!semver.satisfies(globalVersion, compatibleVersion)) {
-    throw new Error('Version "' + globalVersion + '" not compatible with "' + compatibleVersion + '"');
+if (typeof process !== 'undefined') {
+  if (process._heimdall) {
+    var globalVersion = process._heimdall.version;
+    if (!semver.satisfies(globalVersion, compatibleVersion)) {
+      throw new Error('Version "' + globalVersion + '" not compatible with "' + compatibleVersion + '"');
+    }
+    heimdall = process._heimdall;
+  } else {
+    heimdall = process._heimdall = new Heimdall();
   }
 } else {
-  process._heimdall = new Heimdall();
+  heimdall = new Heimdall();
 }
 
-
-module.exports = process._heimdall;
+export default heimdall;

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1,0 +1,36 @@
+export default class Cookie {
+  constructor(node, heimdall) {
+    this.node = node;
+    this.restoreNode = this.node.parent;
+    this.heimdall = heimdall;
+    this.stopped = false;
+  }
+
+  get stats() {
+    return this.node.stats.own;
+  }
+
+  stop() {
+    let monitor;
+
+    if (this.heimdall._current !== this.node) {
+      throw new TypeError('cannot stop: not the current node');
+    } else if (this.stopped === true) {
+      throw new TypeError('cannot stop: already stopped');
+    }
+
+    this.stopped = true;
+    this.heimdall._recordTime();
+    this.heimdall._current = this.restoreNode;
+  }
+
+  resume() {
+    if (this.stopped === false) {
+      throw new TypeError('cannot resume: not stopped');
+    }
+
+    this.stopped = false;
+    this.restoreNode = this.heimdall._current;
+    this.heimdall._current = this.node;
+  }
+}

--- a/lib/heimdall.js
+++ b/lib/heimdall.js
@@ -1,144 +1,137 @@
-'use strict';
+import { Promise } from 'rsvp';
+import Cookie from './cookie';
+import HeimdallNode from './node';
 
-var RSVP = require('rsvp');
-var VERSION = require('../package.json').version;
+export const VERSION = '0.0.1';
 
-module.exports = Heimdall;
-function Heimdall() {
-  this.version = VERSION;
+class Heimdall {
+  constructor() {
+    this.version = VERSION;
 
-  this._reset();
-}
+    this._reset();
+  }
 
-Object.defineProperty(Heimdall.prototype, 'current', {
-  get: function() {
+  get current() {
     return this._current;
   }
-});
 
-Heimdall.prototype._reset = function () {
-  this._nextId = 0;
-  this._current = undefined;
-  this._previousTime = undefined;
-  this.start('heimdall');
-  this._root = this._current;
-  this._monitorSchema = {};
-};
-
-// TODO: implement, and work nicely with DEBUG=*
-Heimdall.prototype.log = function() {};
-Heimdall.prototype.log.verbose = function() {};
-
-Heimdall.prototype.start = function (name, Schema) {
-  var id;
-  var data;
-
-  if (typeof name === 'string') {
-    id = { name: name };
-  } else {
-    id = name;
+  _reset() {
+    this._nextId = 0;
+    this._current = undefined;
+    this._previousTime = undefined;
+    this.start('heimdall');
+    this._root = this._current;
+    this._monitorSchema = {};
   }
 
-  if (typeof Schema === 'function') {
-    data = new Schema();
-  } else {
-    data = {};
+  log() {
+
   }
 
-  this._recordTime();
+  start(name, Schema) {
+    let id;
+    let data;
 
-  var node = new HeimdallNode(this, id, data, this._current);
-  // always true except for root
-  if (this._current) {
-    this._current.addChild(node);
-  }
-  this._current = node;
-
-  return new Cookie(node, this);
-};
-
-Heimdall.prototype._recordTime = function () {
-  var time = process.hrtime();
-  // always true except for root
-  if (this._current) {
-    var delta = (time[0] - this._previousTime[0]) * 1e9 + (time[1] - this._previousTime[1]);
-    this._current.stats.time.self += delta;
-  }
-  this._previousTime = time;
-};
-
-Heimdall.prototype.node = function (name, Schema, callback, context) {
-  if (arguments.length < 3) {
-    callback = Schema;
-    Schema = undefined;
-  }
-
-  var cookie = this.start(name, Schema);
-
-  // NOTE: only works in very specific scenarios, specifically promises must
-  // not escape their parents lifetime. In theory, promises could be augmented
-  // to support those more advanced scenarios.
-  return new RSVP.Promise(function(resolve) {
-    resolve(callback.call(context, cookie.node.stats.own));
-  }).finally(function() {
-    cookie.stop();
-  });
-};
-
-Heimdall.prototype.registerMonitor = function (name, Schema) {
-  if (name === 'own' || name === 'time') {
-    throw new Error('Cannot register monitor at namespace "' + name + '".  "own" and "time" are reserved');
-  }
-  if (this._monitorSchema[name]) {
-    throw new Error('A monitor for "' + name + '" is already registered"');
-  }
-  this._monitorSchema[name] = Schema;
-};
-
-Heimdall.prototype.statsFor = function(name) {
-  var stats = this._current.stats;
-  var Schema;
-
-  if (!stats[name]) {
-    Schema = this._monitorSchema[name];
-    if (!Schema) {
-      throw new Error('No monitor registered for "' + name + '"');
+    if (typeof name === 'string') {
+      id = { name: name };
+    } else {
+      id = name;
     }
-    stats[name] = new Schema();
+
+    if (typeof Schema === 'function') {
+      data = new Schema();
+    } else {
+      data = {};
+    }
+
+    this._recordTime();
+
+    let node = new HeimdallNode(this, id, data, this._current);
+    // always true except for root
+    if (this._current) {
+      this._current.addChild(node);
+    }
+    this._current = node;
+
+    return new Cookie(node, this);
   }
 
-  return stats[name];
-};
+  _recordTime() {
+    let time = process.hrtime();
+    // always true except for root
+    if (this._current) {
+      let delta = (time[0] - this._previousTime[0]) * 1e9 + (time[1] - this._previousTime[1]);
+      this._current.stats.time.self += delta;
+    }
+    this._previousTime = time;
+  }
 
-Heimdall.prototype.toJSON = function () {
-  var result = [];
+  node(name, Schema, callback, context) {
+    if (arguments.length < 3) {
+      callback = Schema;
+      Schema = undefined;
+    }
 
-  this.visitPreOrder(function(node) {
-    result.push(node.toJSON());
-  });
+    let cookie = this.start(name, Schema);
 
-  return { nodes: result }
-  ;
-};
+    // NOTE: only works in very specific scenarios, specifically promises must
+    // not escape their parents lifetime. In theory, promises could be augmented
+    // to support those more advanced scenarios.
+    return new Promise(resolve => {
+      resolve(callback.call(context, cookie.node.stats.own));
+    }).finally(() => cookie.stop())
+  }
 
-Heimdall.prototype.visitPreOrder = function (cb) {
-  this._root.visitPreOrder(cb);
-};
+  registerMonitor(name, Schema) {
+    if (name === 'own' || name === 'time') {
+      throw new Error('Cannot register monitor at namespace "' + name + '".  "own" and "time" are reserved');
+    }
+    if (this._monitorSchema[name]) {
+      throw new Error('A monitor for "' + name + '" is already registered"');
+    }
+    this._monitorSchema[name] = Schema;
+  }
 
-Heimdall.prototype.visitPostOrder = function (cb) {
-  this._root.visitPostOrder(cb);
-};
+  statsFor(name) {
+    let stats = this._current.stats;
+    let Schema;
 
-Heimdall.prototype._createStats = function (data) {
-  var stats = {
-    own: data,
-    time: { self: 0 },
-  };
-  return stats;
-};
+    if (!stats[name]) {
+      Schema = this._monitorSchema[name];
+      if (!Schema) {
+        throw new Error('No monitor registered for "' + name + '"');
+      }
+      stats[name] = new Schema();
+    }
 
-Object.defineProperty(Heimdall.prototype, 'stack', {
-  get: function () {
+    return stats[name];
+  }
+
+  toJSON() {
+    let nodes = [];
+
+    this.visitPreOrder(node => nodes.push(node.toJSON()));
+
+    return { nodes };
+  }
+
+  visitPreOrder(cb) {
+    this._root.visitPreOrder(cb);
+  }
+
+  visitPostOrder(cb) {
+    this._root.visitPostOrder(cb);
+  }
+
+  _createStats(data) {
+    let stats = {
+      own: data,
+      time: { self: 0 },
+    };
+    return stats;
+  }
+
+  get stack() {
     var stack = [];
     var top = this._current;
 
@@ -147,94 +140,13 @@ Object.defineProperty(Heimdall.prototype, 'stack', {
       top = top.parent;
     }
 
-    return stack.map(function(node) {
-      return node.id.name;
-    });
+    return stack.map(node => node.id.name);
   }
-});
-
-function HeimdallNode(heimdall, id, data, parent) {
-  this.heimdall = heimdall;
-
-  this.id = id;
-  this._id = heimdall._nextId++;
-  this.stats = this.heimdall._createStats(data);
-  this.children = [];
-  this.parent = parent;
 }
 
-HeimdallNode.prototype.visitPreOrder = function (cb) {
-  cb(this);
+  // TODO: implement, and work nicely with DEBUG=*
+Heimdall.prototype.log.verbose = function() {};
 
-  for (var i = 0; i < this.children.length; i++) {
-    this.children[i].visitPreOrder(cb);
-  }
-};
+export default Heimdall;
 
-HeimdallNode.prototype.visitPostOrder = function (cb) {
-  for (var i = 0; i < this.children.length; i++) {
-    this.children[i].visitPostOrder(cb);
-  }
 
-  cb(this);
-};
-
-HeimdallNode.prototype.toJSON = function () {
-  return {
-    _id: this._id,
-    id: this.id,
-    stats: this.stats,
-    children: this.children.map(function (child) { return child._id; }),
-  };
-};
-
-HeimdallNode.prototype.toJSONSubgraph = function () {
-  var nodes = [];
-
-  this.visitPreOrder(function(node) {
-    nodes.push(node.toJSON());
-  });
-
-  return nodes;
-};
-
-HeimdallNode.prototype.addChild = function (node) {
-  this.children.push(node);
-};
-
-function Cookie(node, heimdall) {
-  this.node = node;
-  this.restoreNode = this.node.parent;
-  this.heimdall = heimdall;
-  this.stopped = false;
-}
-
-Object.defineProperty(Cookie.prototype, 'stats', {
-  get: function() {
-    return this.node.stats.own;
-  }
-});
-
-Cookie.prototype.stop = function() {
-  var monitor;
-
-  if (this.heimdall._current !== this.node) {
-    throw new TypeError('cannot stop: not the current node');
-  } else if (this.stopped === true) {
-    throw new TypeError('cannot stop: already stopped');
-  }
-
-  this.stopped = true;
-  this.heimdall._recordTime();
-  this.heimdall._current = this.restoreNode;
-};
-
-Cookie.prototype.resume = function() {
-  if (this.stopped === false) {
-    throw new TypeError('cannot resume: not stopped');
-  }
-
-  this.stopped = false;
-  this.restoreNode = this.heimdall._current;
-  this.heimdall._current = this.node;
-};

--- a/lib/node.js
+++ b/lib/node.js
@@ -1,0 +1,48 @@
+export default class HeimdallNode {
+  constructor(heimdall, id, data, parent) {
+    this.heimdall = heimdall;
+
+    this.id = id;
+    this._id = heimdall._nextId++;
+    this.stats = this.heimdall._createStats(data);
+    this.children = [];
+    this.parent = parent;
+  }
+
+  visitPreOrder(cb) {
+    cb(this);
+
+    for (let i = 0; i < this.children.length; i++) {
+      this.children[i].visitPreOrder(cb);
+    }
+  }
+
+  visitPostOrder(cb) {
+    for (let i = 0; i < this.children.length; i++) {
+      this.children[i].visitPostOrder(cb);
+    }
+
+    cb(this);
+  }
+
+  toJSON() {
+    return {
+      _id: this._id,
+      id: this.id,
+      stats: this.stats,
+      children: this.children.map(child => child._id),
+    };
+  }
+
+  toJSONSubgraph() {
+    let nodes = [];
+
+    this.visitPreOrder(node => nodes.push(node.toJSON()));
+
+    return nodes;
+  }
+
+  addChild(node) {
+    this.children.push(node);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "heimdalljs",
   "version": "0.1.0",
   "description": "TODO",
-  "main": "index.js",
+  "main": "dist/bundle.cjs.js",
   "scripts": {
-    "test": "mocha tests/",
+    "build": "rollup --no-strict -c test.config.js && rollup -c index.config.js",
+    "test": "npm run build && mocha dist/tests/bundle.cjs",
     "test:debug": "mocha --no-timeouts debug tests/"
   },
   "repository": {
@@ -22,13 +23,18 @@
   ],
   "devDependencies": {
     "broccoli": "^0.16.9",
-    "chai": "^3.2.0",
-    "chai-as-promised": "^5.1.0",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^5.3.0",
     "chai-files": "^1.2.0",
     "mocha": "^2.2.5",
-    "mocha-jshint": "~2.2.3"
+    "mocha-jshint": "~2.2.3",
+    "rollup": "^0.34.1",
+    "rollup-plugin-buble": "^0.12.1",
+    "rollup-plugin-commonjs": "^3.3.1",
+    "rollup-plugin-node-resolve": "^1.7.1"
   },
   "dependencies": {
-    "semver": "^5.2.0"
+    "rsvp": "^3.2.1",
+    "semver": "^5.3.0"
   }
 }

--- a/test.config.js
+++ b/test.config.js
@@ -1,0 +1,19 @@
+import nodeResolve from 'rollup-plugin-node-resolve';
+import buble from 'rollup-plugin-buble';
+import commonjs from 'rollup-plugin-commonjs';
+
+export default {
+  entry: 'tests/index.js',
+  moduleName: 'heimdall-js',
+  format: 'iife',
+  plugins: [
+    buble(),
+    nodeResolve({ jsnext: true, main: true }),
+    commonjs({ include: 'node_modules/**' })
+  ],
+  targets: [
+    { dest: 'dist/tests/bundle.cjs.js', format: 'cjs' },
+    { dest: 'dist/tests/bundle.umd.js', format: 'umd' },
+    { dest: 'dist/tests/bundle.es.js', format: 'es' },
+  ]
+}


### PR DESCRIPTION
- [x] tests need to work
- [x] cleanup
- [ ] explore dropping semver and rsvp for browser builds.
- [ ] actually make work in the browser
   - [ ] `process.hrtime` isn't a browser thing

likely move VERSION out of package.json (or as a build step)