### PR TITLE
Add Node.remove

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
+  - "node"
+sudo: false
+
+cache:
+  directories:
+    $HOME/.npm
+
+before_install:
+  # prevent the npm loading indicator
+  - npm config --global set spin false
+  # if npm version is less 3.0.0 (lets say 1.x or 2.x) we should attempt to upgrade to 3
+  - if [[ $(npm -v | cut -d '.' -f 1) -lt 3 ]]; then npm i -g npm@^3; fi
+
+install:
+  - npm install --no-optional

--- a/heimdall.js
+++ b/heimdall.js
@@ -1,2 +1,2 @@
-var Heimdall = require('./lib/heimdall');;
+var Heimdall = require('./src/heimdall');;
 module.exports = Heimdall;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Heimdall = require('./lib/heimdall');
+var Heimdall = require('./src/heimdall');
 var semver = require('semver');
 var version = require('./package.json').version;
 var compatibleVersion = '^' + version;

--- a/src/cookie.js
+++ b/src/cookie.js
@@ -1,0 +1,37 @@
+module.exports = Cookie;
+function Cookie(node, heimdall) {
+  this.node = node;
+  this.restoreNode = this.node.parent;
+  this.heimdall = heimdall;
+  this.stopped = false;
+}
+
+Object.defineProperty(Cookie.prototype, 'stats', {
+  get: function() {
+    return this.node.stats.own;
+  }
+});
+
+Cookie.prototype.stop = function() {
+  var monitor;
+
+  if (this.heimdall._current !== this.node) {
+    throw new TypeError('cannot stop: not the current node');
+  } else if (this.stopped === true) {
+    throw new TypeError('cannot stop: already stopped');
+  }
+
+  this.stopped = true;
+  this.heimdall._recordTime();
+  this.heimdall._current = this.restoreNode;
+};
+
+Cookie.prototype.resume = function() {
+  if (this.stopped === false) {
+    throw new TypeError('cannot resume: not stopped');
+  }
+
+  this.stopped = false;
+  this.restoreNode = this.heimdall._current;
+  this.heimdall._current = this.node;
+};

--- a/src/node.js
+++ b/src/node.js
@@ -1,0 +1,73 @@
+module.exports = HeimdallNode;
+function HeimdallNode(heimdall, id, data, parent) {
+  this.heimdall = heimdall;
+
+  this.id = id;
+  this._id = heimdall._nextId++;
+  this.stats = this.heimdall._createStats(data);
+  this.children = [];
+  this.parent = parent;
+}
+
+Object.defineProperty(HeimdallNode.prototype, 'isRoot', {
+  get: function () {
+    return this.parent === undefined;
+  },
+});
+
+HeimdallNode.prototype.visitPreOrder = function (cb) {
+  cb(this);
+
+  for (var i = 0; i < this.children.length; i++) {
+    this.children[i].visitPreOrder(cb);
+  }
+};
+
+HeimdallNode.prototype.visitPostOrder = function (cb) {
+  for (var i = 0; i < this.children.length; i++) {
+    this.children[i].visitPostOrder(cb);
+  }
+
+  cb(this);
+};
+
+HeimdallNode.prototype.remove = function () {
+  if (!this.parent) {
+    throw new Error('Cannot remove the root heimdalljs node.');
+  }
+  if (this.heimdall.current === this) {
+    throw new Error('Cannot remove an active heimdalljs node.');
+  }
+
+  var index = this.parent.children.indexOf(this);
+  if (index < 0) {
+    throw new Error('Child(' + this._id + ') not found in Parent(' + this.parent._id + ').  Something is very wrong.');
+  }
+  this.parent.children.splice(index, 1);
+
+  return this;
+};
+
+HeimdallNode.prototype.toJSON = function () {
+  return {
+    _id: this._id,
+    id: this.id,
+    stats: this.stats,
+    children: this.children.map(function (child) { return child._id; }),
+  };
+};
+
+HeimdallNode.prototype.toJSONSubgraph = function () {
+  var nodes = [];
+
+  this.visitPreOrder(function(node) {
+    nodes.push(node.toJSON());
+  });
+
+  return nodes;
+};
+
+HeimdallNode.prototype.addChild = function (node) {
+  this.children.push(node);
+};
+

--- a/tests/index.js
+++ b/tests/index.js
@@ -340,6 +340,64 @@ describe('heimdall', function() {
     });
   });
 
+  describe('nodes', function() {
+    function nodeNames() {
+      var count = 0;
+      var names = [];
+
+      heimdall.visitPreOrder(function (node) {
+        names.push(node.id.name);
+      });
+
+      // ignore root
+      return names.slice(1).join(' ');
+    }
+
+    describe('.remove', function() {
+      describe('for the root node', function() {
+        it('throws an error', function() {
+          expect(function () {
+            expect(heimdall.current.isRoot).to.equal(true);
+            heimdall.current.remove();
+          }).to.throw('Cannot remove the root heimdalljs node.');
+        });
+      });
+
+      describe('for non-root nodes', function() {
+        it('frees the node from its parent', function() {
+          expect(nodeNames()).to.equal('');
+
+          var cookieA = heimdall.start('a');
+          var cookieAA = heimdall.start('aa');
+
+          expect(nodeNames()).to.equal('a aa');
+
+          cookieAA.stop();
+
+          expect(nodeNames()).to.equal('a aa');
+
+          expect(cookieAA.node.remove()).to.equal(cookieAA.node);
+
+          expect(nodeNames()).to.equal('a');
+        });
+      });
+
+      // Really this is an error for any active node (ie path from current ->
+      // root
+      //
+      // A case could be made it's an error for any node with an outstanding
+      // cookie
+      describe('for the current node', function() {
+        it('throws an error', function() {
+          var cookie = heimdall.start('node');
+          expect(function () {
+            cookie.node.remove();
+          }).to.throw('Cannot remove an active heimdalljs node.');
+        });
+      });
+    });
+  });
+
   describe('monitors', function() {
     function MonitorSchema() {
       this.mstatA = 0;

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,7 +1,7 @@
 var chai = require('chai'), expect = chai.expect;
 var chaiAsPromised = require('chai-as-promised');
 var chaiFiles = require('chai-files'), file = chaiFiles.file;
-var RSVP = require('RSVP');
+var RSVP = require('rsvp');
 var heimdall = require('../');
 
 chai.use(chaiAsPromised);

--- a/tests/index.js
+++ b/tests/index.js
@@ -188,7 +188,13 @@ describe('heimdall', function() {
     it('always includes time', function() {
       return heimdall.node('node-a', function () {}).then(function () {
         var json = heimdall.toJSON();
-        var nodeA = json.nodes.find(function (n) { return n.id.name === 'node-a'; });
+        var nodeA;
+        for (var i=0; i<json.nodes.length; ++i) {
+          if (json.nodes[i].id.name === 'node-a') {
+            nodeA = json.nodes[i];
+            break;
+          }
+        }
 
         expect(nodeA).to.not.eql(undefined);
         expect(typeof nodeA.stats.time).to.eql('object');


### PR DESCRIPTION
This lets long running processes dump data (via `toJSONSubgraph`) and then
remove refs to avoid leaking memory.

Also
- cleanup (split up heimdalljs into constituent parts)