### PR TITLE
Add forEachChild

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ var myInstance = new Heimdall();
   written via `JSON.stringify` and then consumed by downstream apps (see eg
   [broccoli-viz](https://github.com/stefanpenner/broccoli-viz)).
 - `visitPreOrder(callback)` sugar for `root.visitPreOrder(callback)`
-- `visitPostOrder(callback)`` sugar for `root.visitPostOrder(callback)`
+- `visitPostOrder(callback)` sugar for `root.visitPostOrder(callback)`
 
 
 ### HeimdallNode
@@ -77,6 +77,8 @@ var myInstance = new Heimdall();
   depth-first pre-order traversal.
 - `visitPostOrder(callback)` visit the subtree rooted at this node with a
   depth-first post-order traversal.
+- `forEachChild(callback)` invoke `callback` for each child of this node (but
+  not other descendants).
 - `remove` remove this node from its parent.  May only be called on an inactive,
   non-root node.  Intended for long-running applications to free up memory after
   saving a subgraph via `toJSONSubgraph`.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:browser": "rollup --no-strict -c browser.config.js",
     "build:test": "rollup --no-strict -c test.config.js",
     "test": "npm run build:node && npm run build:test && mocha dist/tests/bundle.cjs",
-    "test:debug": "mocha --no-timeouts debug tests/"
+    "test:debug": "mocha --no-timeouts debug dist/tests/bundle.cjs"
   },
   "repository": {
     "type": "git",

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -8,4 +8,4 @@ setupSession(window);
 // browser equivalent of heimdall.js
 self.Heimdall = Heimdall;
 
-export default new Heimdall(window._heimdall_session_1);
+export default new Heimdall(window._heimdall_session_2);

--- a/src/node.js
+++ b/src/node.js
@@ -39,6 +39,12 @@ export default class HeimdallNode {
     cb(this);
   }
 
+  forEachChild(cb) {
+    for (let i=0; i<this._children.length; ++i) {
+      cb(this._children[i]);
+    }
+  }
+
   remove() {
     if (!this.parent) {
       throw new Error('Cannot remove the root heimdalljs node.');

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -5,4 +5,4 @@ import setupSession from '../setup-session';
 
 setupSession(process);
 
-export default new Heimdall(process._heimdall_session_1);
+export default new Heimdall(process._heimdall_session_2);

--- a/src/setup-session.js
+++ b/src/setup-session.js
@@ -3,7 +3,7 @@ import Session from './session';
 export default function setupSession(global) {
 
   // The name of the property encodes the session/node compatibilty version
-  if (!global._heimdall_session_1) {
-    global._heimdall_session_1 = new Session();
+  if (!global._heimdall_session_2) {
+    global._heimdall_session_2 = new Session();
   }
 }

--- a/tests/global.js
+++ b/tests/global.js
@@ -14,11 +14,11 @@ describe('setupSession', function() {
       const global = {};
       const session = new Session();
 
-      global._heimdall_session_1 = session;
+      global._heimdall_session_2 = session;
 
       setupSession(global);
 
-      expect(global._heimdall_session_1).to.equal(session);
+      expect(global._heimdall_session_2).to.equal(session);
     });
   });
 
@@ -26,11 +26,11 @@ describe('setupSession', function() {
     it('creates a new session saves it on the global', function() {
       const global = {};
 
-      expect(global._heimdall_session_1).to.equal(undefined);
+      expect(global._heimdall_session_2).to.equal(undefined);
 
       setupSession(global);
 
-      expect(global._heimdall_session_1).to.be.an.instanceOf(Session);
+      expect(global._heimdall_session_2).to.be.an.instanceOf(Session);
     });
   });
 });

--- a/tests/public-api.js
+++ b/tests/public-api.js
@@ -459,5 +459,15 @@ describe('HeimdallNode', function() {
         'a1.b', 'a1', 'a2', 'root',
       ]);
     });
+
+    it('forEachChild visits each child only', function() {
+      let path = [];
+
+      root.forEachChild(node => path.push(node.id.name));
+
+      expect(path).to.eql([
+        'a1', 'a2'
+      ]);
+    });
   });
 });


### PR DESCRIPTION
We had some things depending on `node.children`.  We don't want direct array access to be in the public API, so this adds a child visitor (as opposed to a subtree visitor).  We may want an iterator over which users have more control, although that will be more obviously useful for analysis tools that operate on the resulting JSON.

As this changes the `HeimdallNode` api, a session version bump is necessary.