### PR TITLE
Add timing test

### DIFF
--- a/src/time.js
+++ b/src/time.js
@@ -4,19 +4,18 @@ let timeNS;
 // https://gist.github.com/paulirish/5438650
 let now;
 if (typeof performance === 'object' && typeof performance.now === 'function') {
-  now = function () {
+  now = function now() {
     return performance.now.call(performance);
   };
 } else {
-  now = Date.now || function () { return new Date().getTime(); };
+  const dateOffset = new Date().getTime();
+  now = function now() { return new Date().getTime() - dateOffset; };
 }
 
 const dateOffset = now();
 
 export function timeFromDate() {
-  let timeMS = now() - dateOffset;
-
-  return Math.floor(timeMS * 1e6);
+  return Math.floor(now() * 1e6);
 }
 
 export function timeFromHRTime() {

--- a/tests/time.js
+++ b/tests/time.js
@@ -20,7 +20,7 @@ describe('timeFromDate', function() {
 
       expect(markB).to.be.gte(15 * 1e6);
       expect(markB - markA).to.be.gte(15 * 1e6);
-      expect(markB - markA).to.be.lt(20 * 1e6);
+      expect(markB - markA).to.be.lt(25 * 1e6);
     });
   });
 });


### PR DESCRIPTION
- Adds a test for #23
- Also improves a brittle test elsewhere
- Fixes `performance.now` polyfilling