### PR TITLE
Improve benchmarks

### DIFF
--- a/bench/cookie.js
+++ b/bench/cookie.js
@@ -6,7 +6,7 @@ var node = new Node(heimdall, { name: 'some-node' });
 // tests
 module.exports = newCookie;
 function newCookie() {
-  new Cookie(node, heimdall);
+  return new Cookie(node, heimdall);
 }
 
 // loop is for quick "hot code" testing

--- a/bench/index.js
+++ b/bench/index.js
@@ -1,5 +1,8 @@
 // basic runner;
 console.log('running instantiation tests:');
+var Heimdall = require('../heimdall');
+process.Heimdall = Heimdall;
+
 require('do-you-even-bench')([
   {
     name: 'node',
@@ -8,5 +11,9 @@ require('do-you-even-bench')([
   {
     name: 'cookie creation',
     fn: require('./cookie'),
-  }
+  },
+  require('./start-stop'),
+  require('./start-stop-ownstats'),
+  require('./start-stop-monitor'),
+  require('./start-stop-allstats'),
 ]);

--- a/bench/node.js
+++ b/bench/node.js
@@ -4,7 +4,7 @@ var Node = heimdall.constructor.Node;
 // tests
 module.exports = newNode;
 function newNode() {
-  new Node(heimdall, { name: 'some-node' });
+  return new Node(heimdall, { name: 'some-node' });
 }
 
 // loop is for quick "hot code" testing

--- a/bench/start-stop-allstats.js
+++ b/bench/start-stop-allstats.js
@@ -1,0 +1,24 @@
+module.exports = {
+  count: 1000,
+  name: 'Start Stop (with own stats + monitor)',
+  setup: function() {
+    var Heimdall = process.Heimdall;
+    var heimdall = new Heimdall();
+    function MySchema() {
+      this.x = 0;
+    }
+    function MonitorSchema() {
+      this.x = 0;
+    }
+    heimdall.registerMonitor('mon', MonitorSchema);
+  },
+  fn: function() {
+    var a = heimdall.start('a');
+    var b = heimdall.start('b', MySchema);
+    b.stats.x++;
+    heimdall.statsFor('mon').x++;
+    b.stop();
+    a.stop();
+  }
+};
+

--- a/bench/start-stop-monitor.js
+++ b/bench/start-stop-monitor.js
@@ -1,0 +1,19 @@
+module.exports = {
+  count: 1000,
+  name: 'Start Stop (with monitor)',
+  setup: function() {
+    var Heimdall = process.Heimdall;
+    var heimdall = new Heimdall();
+    function MonitorSchema() {
+      this.x = 0;
+    }
+    heimdall.registerMonitor('mon', MonitorSchema);
+  },
+  fn: function() {
+    var a = heimdall.start('a');
+    var b = heimdall.start('b');
+    heimdall.statsFor('mon').x++;
+    b.stop();
+    a.stop();
+  }
+};

--- a/bench/start-stop-ownstats.js
+++ b/bench/start-stop-ownstats.js
@@ -1,0 +1,18 @@
+module.exports = {
+  count: 1000,
+  name: 'Start Stop (with own stats)',
+  setup: function() {
+    var Heimdall = process.Heimdall;
+    var heimdall = new Heimdall();
+    function MySchema() {
+      this.x = 0;
+    }
+  },
+  fn: function() {
+    var a = heimdall.start('a');
+    var b = heimdall.start('b', MySchema);
+    b.stats.x++;
+    b.stop();
+    a.stop();
+  }
+};

--- a/bench/start-stop.js
+++ b/bench/start-stop.js
@@ -1,0 +1,14 @@
+module.exports = {
+  count: 1000,
+  name: 'Start Stop',
+  setup: function() {
+    var Heimdall = process.Heimdall;
+    var heimdall = new Heimdall();
+  },
+  fn: function() {
+    var a = heimdall.start('a');
+    var b = heimdall.start('b');
+    b.stop();
+    a.stop();
+  }
+};


### PR DESCRIPTION
Add the comprehensive benchmark from perf/1-1.  This is intended to be a point
of comparison to ensure we don't have any major regressions when switching to
the token API.

Also fix the constructor benchmarks.  Initially bench/node.js showed a massive
regression in perf/1-1, but irhydra2 demonstrated that this is because the
original benchmark was a) inlining the constructor and b) not actually doing any
writes.