### PR TITLE
Fix build issues

### DIFF
--- a/browser.config.js
+++ b/browser.config.js
@@ -11,7 +11,7 @@ export default {
       exclude: 'node_modules/**'
     }),
     nodeResolve({ jsnext: true, main: true }),
-    commonjs({ include: 'node_modules/**' }),
+    commonjs({ include: 'node_modules/**', ignoreGlobal: true }),
   ],
   targets: [
     { dest: 'dist/heimdalljs.umd.js', format: 'umd' },

--- a/node.config.js
+++ b/node.config.js
@@ -10,7 +10,7 @@ export default {
       exclude: 'node_modules/**'
     }),
     nodeResolve({ jsnext: true, main: true }),
-    commonjs({ include: 'node_modules/**' }),
+    commonjs({ include: 'node_modules/**', ignoreGlobal: true }),
   ],
   targets: [
     { dest: 'dist/heimdalljs.cjs.js', format: 'cjs' },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "heimdall.js"
   ],
   "devDependencies": {
-    "babel-preset-es2015": "6.13.0",
+    "babel-preset-es2015": "^6.13.0",
     "babel-preset-es2015-rollup": "^1.1.1",
     "broccoli": "^0.16.9",
     "chai": "^3.2.0",
@@ -48,6 +48,6 @@
     "rollup-plugin-node-resolve": "^1.7.1"
   },
   "dependencies": {
-    "rsvp": "^3.2.1"
+    "rsvp": "~3.2.1"
   }
 }

--- a/test.config.js
+++ b/test.config.js
@@ -10,11 +10,11 @@ export default {
       exclude: 'node_modules/**'
     }),
     nodeResolve({ jsnext: true, main: true }),
-    commonjs({ include: 'node_modules/**' })
+    commonjs({ include: 'node_modules/**', ignoreGlobal: true })
   ],
   targets: [
     { dest: 'dist/tests/bundle.cjs.js', format: 'cjs' },
     { dest: 'dist/tests/bundle.umd.js', format: 'umd' },
     { dest: 'dist/tests/bundle.es.js', format: 'es' },
   ]
-}
+};


### PR DESCRIPTION
We have to skip rsvp v3.3.1 (and possibly v3.3.0) because it contains invalid
es6 that trolls rollup.  Once v3.3.2 is released we can go back to rsvp@^3.2.1
or equivalent.

We also need to ignore globals when rolling up rsvp with es6.  Otherwise
rollup-plugin-commonjs will try to wrap a module around platform.js inside rsvp
and then complain about exports not being at the top level.