### PR TITLE
Implement hasMonitor + tests

### DIFF
--- a/browser.config.js
+++ b/browser.config.js
@@ -11,7 +11,7 @@ export default {
       exclude: 'node_modules/**'
     }),
     nodeResolve({ jsnext: true, main: true }),
-    commonjs({ include: 'node_modules/**' }),
+    commonjs({ include: 'node_modules/**', ignoreGlobal: true }),
   ],
   targets: [
     { dest: 'dist/heimdalljs.umd.js', format: 'umd' },

--- a/node.config.js
+++ b/node.config.js
@@ -10,7 +10,7 @@ export default {
       exclude: 'node_modules/**'
     }),
     nodeResolve({ jsnext: true, main: true }),
-    commonjs({ include: 'node_modules/**' }),
+    commonjs({ include: 'node_modules/**', ignoreGlobal: true }),
   ],
   targets: [
     { dest: 'dist/heimdalljs.cjs.js', format: 'cjs' },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "heimdall.js"
   ],
   "devDependencies": {
-    "babel-preset-es2015": "6.13.0",
+    "babel-preset-es2015": "^6.13.0",
     "babel-preset-es2015-rollup": "^1.1.1",
     "broccoli": "^0.16.9",
     "chai": "^3.2.0",
@@ -45,6 +45,6 @@
     "rollup-plugin-node-resolve": "^1.7.1"
   },
   "dependencies": {
-    "rsvp": "^3.2.1"
+    "rsvp": "~3.2.1"
   }
 }

--- a/src/heimdall.js
+++ b/src/heimdall.js
@@ -90,6 +90,10 @@ export default class Heimdall{
       finally(() => cookie.stop());
   }
 
+  hasMonitor(name) {
+    return this._session.monitorSchemas.has(name);
+  }
+
   registerMonitor(name, Schema) {
     if (name === 'own' || name === 'time') {
       throw new Error('Cannot register monitor at namespace "' + name + '".  "own" and "time" are reserved');

--- a/src/heimdall.js
+++ b/src/heimdall.js
@@ -98,7 +98,7 @@ export default class Heimdall{
     if (name === 'own' || name === 'time') {
       throw new Error('Cannot register monitor at namespace "' + name + '".  "own" and "time" are reserved');
     }
-    if (this._session.monitorSchemas.has(name)) {
+    if (this.hasMonitor(name)) {
       throw new Error('A monitor for "' + name + '" is already registered"');
     }
 

--- a/test.config.js
+++ b/test.config.js
@@ -10,11 +10,11 @@ export default {
       exclude: 'node_modules/**'
     }),
     nodeResolve({ jsnext: true, main: true }),
-    commonjs({ include: 'node_modules/**' })
+    commonjs({ include: 'node_modules/**', ignoreGlobal: true })
   ],
   targets: [
     { dest: 'dist/tests/bundle.cjs.js', format: 'cjs' },
     { dest: 'dist/tests/bundle.umd.js', format: 'umd' },
     { dest: 'dist/tests/bundle.es.js', format: 'es' },
   ]
-}
+};

--- a/tests/heimdall.js
+++ b/tests/heimdall.js
@@ -445,6 +445,18 @@ describe('heimdall', function() {
       counter = 0;
     });
 
+    it('hasMonitor returns false if a given namespace is not being used', function () {
+      expect(heimdall.hasMonitor('some-monitor')).to.equal(false);
+    });
+
+    it('hasMonitor returns true if a given namespace is being used', function () {
+      class MySchema {}
+
+      heimdall.registerMonitor('some-monitor', MySchema);
+
+      expect(heimdall.hasMonitor('some-monitor')).to.equal(true);
+    });
+
     it('throws if another schema is registered at the given namespace', function () {
       class MySchema {}
 


### PR DESCRIPTION
Need a way to check if a monitor has been registered so you can avoid double-registering monitors for the same namespace.

This also cherry-picks 517654e8532f2a4ff7cbdb682d441161a3e65280 from master on order to fix build issues stemming from `rsvp`.