### PR TITLE
Cleanup tested Node versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "4"
-  - "5"
   - "6"
   - "node"
 sudo: false


### PR DESCRIPTION
Remove 0.10 and 5 (they are both unsupported).