### PR TITLE
Add public API's to CJS exports.

### DIFF
--- a/src/runtime/node/index.js
+++ b/src/runtime/node/index.js
@@ -7,9 +7,12 @@ import setupSession from '../setup-session';
 
 setupSession(process);
 
-Heimdall.now = now;
-Heimdall.Session = Session;
-Heimdall.Tree = Tree;
-Heimdall.Node = Node;
+const defaultHeimdall = new Heimdall(process._heimdall_session_3);
 
-export default new Heimdall(process._heimdall_session_3);
+defaultHeimdall.now = now;
+defaultHeimdall.Heimdall = Heimdall;
+defaultHeimdall.Session = Session;
+defaultHeimdall._Tree = Tree;
+defaultHeimdall._Node = Node;
+
+export default defaultHeimdall;


### PR DESCRIPTION
This changes the mechanism that we use to export `Heimdall`, `Session`, `Tree`, and `Node` so that they are actually exported and available in a more intuitive way in Node.

Prior to this change, to create your own `Heimdall` instance and `Session` (most often important for testing) you were forced to do something like:

```js
const heimdall = require('heimdalljs');
const Heimdall = Object.getPrototypeOf(heimdall).constructor;
const Session = Heimdall.Session;
const Tree = Heimdall.Tree;
```

After these changes the following (IMO much more intuitive) usage works:

```js
const heimdall = require('heimdalljs');
const {
  Heimdall,
  Session,
  _Tree
} = heimdall;
```

Fixes #49.