### PR TITLE
Removes now benchmark

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -5,7 +5,6 @@ var benchmarkRunner = require('do-you-even-bench');
 _global.Heimdall = Heimdall;
 
 var benchmarks = [
-  require('./test/now'),
   require('./test/start-stop'),
   require('./test/start-stop-monitor'),
   require('./test/monitor'),

--- a/bench/test/now.js
+++ b/bench/test/now.js
@@ -1,9 +1,0 @@
-module.exports = {
-  name: 'now()',
-  setup: function() {
-    var now = Heimdall.now;
-  },
-  fn: function() {
-    return now();
-  }
-};


### PR DESCRIPTION
The best way to fix the benchmark is to remove it. I kid.

After talking to @runspired, it was decided to remove `now` benchmark b/c it's no longer relevant. Once [support for `performance.mark`](https://github.com/heimdalljs/heimdalljs-lib/pull/53) lands, I don't think performance API measurements are needed. Aslo, heimdall `0.3` no longer exposes `now`. 

cc @hjdivad 