### PR TITLE
Excluding tests from build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/heimdalljs.cjs.js",
   "jsnext:main": "dist/heimdalljs.es.js",
   "scripts": {
-    "build": "npm run build:node && npm run build:browser && npm run build:test",
+    "build": "npm run build:node && npm run build:browser",
     "build:node": "rollup --no-strict -c node.config.js",
     "build:browser": "rollup --no-strict -c browser.config.js",
     "build:test": "rollup --no-strict -c test.config.js",


### PR DESCRIPTION
addresses #84 

turns out that we were including our transpiled tests as a part of the build which we likely should avoid. I'm dubious to why transpiled tests take up 772K though.