### PR TITLE
Fixes tslint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "build:node": "rollup --no-strict -c node.config.js",
     "build:browser": "rollup --no-strict -c browser.config.js",
     "build:test": "rollup --no-strict -c test.config.js",
-    "test": "mocha dist/tests/bundle.cjs --scenario=default && mocha dist/tests/bundle.cjs --scenario=array-fallback",
+    "test": "yarn run tslint && mocha dist/tests/bundle.cjs --scenario=default && mocha dist/tests/bundle.cjs --scenario=array-fallback",
     "test:debug": "mocha --no-timeouts debug dist/tests/bundle.cjs",
     "build_and_test": "npm run build:test && npm run test",
-    "tslint": "tslint -c tslint.json --project tsconfig.json",
+    "tslint": "tslint --typecheck -c tslint.json --project tsconfig.json",
+    "tslint:format": "tslint --typecheck -c tslint.json --project tsconfig.json --fix",
     "trace": "node --trace-hydrogen --trace_phase=Z --trace_deopt --code_comments --hydrogen_track_positions --redirect_code_traces bench/ ",
     "prepublish": "npm run build"
   },
@@ -49,8 +50,8 @@
     "rollup-plugin-node-resolve": "^1.7.1",
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-typescript": "^0.8.1",
-    "tslint": "^4.4.2",
-    "typescript": "^2.2"
+    "tslint": "^4.5.1",
+    "typescript": "^2.2.1"
   },
   "dependencies": {
     "rsvp": "~3.2.1"

--- a/src/heimdall-tree/leaf.ts
+++ b/src/heimdall-tree/leaf.ts
@@ -1,17 +1,17 @@
 import HeimdallNode from './node';
 import JsonSerializable from '../interfaces/json-serializable';
 
-export default class HeimdallLeaf implements JsonSerializable<Object> {
+export default class HeimdallLeaf implements JsonSerializable<object> {
   private _id: string;
 
-  owner: HeimdallNode;
-  previousOp: string;
-  startTime: number;
-  annotations: Object[];
-  nextOp: string;
-  endTime: number;
-  counters: Object;
-  name: string;
+  public owner: HeimdallNode;
+  public previousOp: string;
+  public startTime: number;
+  public annotations: Array<object>;
+  public nextOp: string;
+  public endTime: number;
+  public counters: object;
+  public name: string;
 
   constructor() {
     // set on start
@@ -27,7 +27,7 @@ export default class HeimdallLeaf implements JsonSerializable<Object> {
     this.nextOp = null;
     this.endTime = 0;
     this.counters = null;
-    this.name= null;
+    this.name = null;
   }
 
   get selfTime(): number {
@@ -38,27 +38,27 @@ export default class HeimdallLeaf implements JsonSerializable<Object> {
     return this.endTime !== 0;
   }
 
-  annotate(annotation: Object): void {
+  public annotate(annotation: object): void {
     if (this.annotations === null) {
       this.annotations = [];
     }
     this.annotations.push(annotation);
   }
 
-  start(owner: HeimdallNode, previousOp: string, time: number): void {
+  public start(owner: HeimdallNode, previousOp: string, time: number): void {
     this.owner = owner;
     this.previousOp = previousOp;
     this.startTime = time;
   }
 
-  stop(nextOp: string, time: number, counters: Object): void {
+  public stop(nextOp: string, time: number, counters: object): void {
     this.nextOp = nextOp;
     this.endTime = time;
     this.counters = counters;
     this._id = this.name = `[${this.owner.name}]#${this.previousOp}:${nextOp}`;
   }
 
-  toJSON(): Object {
+  public toJSON(): object {
     return {
       _id: this._id,
       name: this.name,

--- a/src/heimdall-tree/node.ts
+++ b/src/heimdall-tree/node.ts
@@ -1,16 +1,16 @@
 import HeimdallLeaf from './leaf';
 import JsonSerializable from '../interfaces/json-serializable';
 
-export default class HeimdallNode implements JsonSerializable<Object> {
+export default class HeimdallNode implements JsonSerializable<object> {
   private _id: number;
 
-  name: string;
-  parent: HeimdallNode;
-  resumeNode: HeimdallNode;
-  stopped: boolean;
-  leaves: HeimdallLeaf[];
-  nodes: HeimdallNode[];
-  children: any[];
+  public name: string;
+  public parent: HeimdallNode;
+  public resumeNode: HeimdallNode;
+  public stopped: boolean;
+  public leaves: HeimdallLeaf[];
+  public nodes: HeimdallNode[];
+  public children: any[];
 
   constructor(name: string, id: number) {
     this._id = id;
@@ -23,8 +23,12 @@ export default class HeimdallNode implements JsonSerializable<Object> {
     this.children = [];
   }
 
-  get stats(): Object {
-    let own = {
+  get id(): number {
+    return this._id;
+  }
+
+  get stats(): object {
+    const own = {
       selfTime: 0,
       duration: 0,
       startTime: this.leaves[0].startTime,
@@ -32,25 +36,23 @@ export default class HeimdallNode implements JsonSerializable<Object> {
     };
     own.duration = own.endTime - own.startTime;
 
-    let counters: any[] = [];
-    let annotations: any[] = [];
-    let stats: Object = {
-      self: own,
-      // _annotations: annotations,
-      // _counters: counters
+    const counters: any[] = [];
+    const annotations: any[] = [];
+    const stats: object = {
+      self: own
     };
 
     this.forEachLeaf((leaf: HeimdallLeaf) => {
       own.selfTime += leaf.selfTime;
       annotations.push(leaf.annotations);
 
-      for (let namespace in leaf.counters) {
-        let value: any = leaf.counters[namespace];
+      for (const namespace in leaf.counters) {
+        const value: any = leaf.counters[namespace];
 
         if (!stats.hasOwnProperty(namespace)) {
           stats[namespace] = value;
         } else {
-          for (let label in value) {
+          for (const label in value) {
             stats[namespace][label] += value[label];
           }
         }
@@ -62,14 +64,14 @@ export default class HeimdallNode implements JsonSerializable<Object> {
     return stats;
   }
 
-  stop(): void | never {
+  public stop(): void | never {
     if (this.stopped === true) {
       throw new Error('Cannot Stop node, already stopped!');
     }
     this.stopped = true;
   }
 
-  resume(resumeNode: HeimdallNode): void | never {
+  public resume(resumeNode: HeimdallNode): void | never {
     if (!this.stopped) {
       throw new Error('Cannot Resume node, already running!');
     }
@@ -77,13 +79,13 @@ export default class HeimdallNode implements JsonSerializable<Object> {
     this.stopped = false;
   }
 
-  addLeaf(leaf: HeimdallLeaf): void {
+  public addLeaf(leaf: HeimdallLeaf): void {
     leaf.owner = this;
     this.leaves.push(leaf);
     this.children.push(leaf);
   }
 
-  addNode(node: HeimdallNode): void | never {
+  public addNode(node: HeimdallNode): void | never {
     if (node.parent) {
       throw new Error(`Cannot set parent of node '${node.name}', node already has a parent!`);
     }
@@ -97,7 +99,7 @@ export default class HeimdallNode implements JsonSerializable<Object> {
     return this.parent === null;
   }
 
-  visitPreOrder(cb: Function): void {
+  public visitPreOrder(cb: (HeimdallNode) => void): void {
     cb(this);
 
     for (let i = 0; i < this.nodes.length; i++) {
@@ -105,7 +107,7 @@ export default class HeimdallNode implements JsonSerializable<Object> {
     }
   }
 
-  visitPostOrder(cb: Function): void {
+  public visitPostOrder(cb: (HeimdallNode) => void): void {
     for (let i = 0; i < this.nodes.length; i++) {
       this.nodes[i].visitPostOrder(cb);
     }
@@ -113,36 +115,36 @@ export default class HeimdallNode implements JsonSerializable<Object> {
     cb(this);
   }
 
-  forEachNode(cb: Function): void {
-    for (let i=0; i<this.nodes.length; ++i) {
+  public forEachNode(cb: (HeimdallNode) => void): void {
+    for (let i = 0; i < this.nodes.length; ++i) {
       cb(this.nodes[i]);
     }
   }
 
-  forEachLeaf(cb: Function): void {
-    for (let i=0; i<this.leaves.length; ++i) {
+  public forEachLeaf(cb: (HeimdallLeaf) => void): void {
+    for (let i = 0; i < this.leaves.length; ++i) {
       cb(this.leaves[i]);
     }
   }
 
-  forEachChild(cb: Function): void {
-    for (let i=0; i<this.children.length; ++i) {
+  public forEachChild(cb: (any) => void): void {
+    for (let i = 0; i < this.children.length; ++i) {
       cb(this.children[i]);
     }
   }
 
-  toJSON(): Object {
+  public toJSON(): object {
     return {
       _id: this._id,
       name: this.name,
       leaves: this.leaves.map(leaf => leaf.toJSON()),
       nodes: this.nodes.map(child => child._id),
-      children: this.children.map(child => child._id )
+      children: this.children.map(child => child._id)
     };
   }
 
-  toJSONSubgraph(): HeimdallNode[] {
-    let nodes: HeimdallNode[] = [];
+  public toJSONSubgraph(): HeimdallNode[] {
+    const nodes: HeimdallNode[] = [];
 
     this.visitPreOrder(node => nodes.push(node.toJSON()));
 

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -10,8 +10,12 @@ import JsonSerializable from '../interfaces/json-serializable';
 
 const VERSION = 'VERSION_STRING_PLACEHOLDER';
 
-export default class Heimdall implements JsonSerializable<Object> {
+export default class Heimdall implements JsonSerializable<object> {
   private _session: Session;
+
+  private _retrieveCounters(): Uint32Array | number[] | FastIntArray {
+    return this._monitors.cache();
+  }
 
   static get VERSION(): string {
     return VERSION;
@@ -38,33 +42,29 @@ export default class Heimdall implements JsonSerializable<Object> {
     return this._session.events;
   }
 
-  _retrieveCounters(): Uint32Array | number[] | FastIntArray {
-    return this._monitors.cache();
-  }
-
-  start(name: string): number {
+  public start(name: string): number {
     return this._session.events.push(OpCodes.OP_START, name, now(), this._retrieveCounters());
   }
 
-  stop(token: number): void {
+  public stop(token: number): void {
     this._session.events.push(OpCodes.OP_STOP, token, now(), this._retrieveCounters());
   }
 
-  resume(token: number): void {
+  public resume(token: number): void {
     this._session.events.push(OpCodes.OP_RESUME, token, now(), this._retrieveCounters());
   }
 
-  annotate(info: Uint32Array | number[] | FastIntArray): void {
+  public annotate(info: Uint32Array | number[] | FastIntArray): void {
     // This has the side effect of making events heterogenous, as info is an object
     // while counters will always be `null` or an `Array`
     this._session.events.push(OpCodes.OP_ANNOTATE, NULL_NUMBER, NULL_NUMBER, info);
   }
 
-  hasMonitor(name): boolean {
+  public hasMonitor(name): boolean {
     return !!this._monitors.has(name);
   }
 
-  registerMonitor(name: string, ...keys: string[]): never | Object {
+  public registerMonitor(name: string, ...keys: string[]): never | object {
     if (name === 'own' || name === 'time') {
       throw new Error('Cannot register monitor at namespace "' + name + '".  "own" and "time" are reserved');
     }
@@ -75,11 +75,11 @@ export default class Heimdall implements JsonSerializable<Object> {
     return this._monitors.registerNamespace(name, keys);
   }
 
-  increment(token: number): void {
+  public increment(token: number): void {
     this._session.monitors.increment(token);
   }
 
-  configFor(name: string): any {
+  public configFor(name: string): any {
     let config = this._session.configs.get(name);
 
     if (!config) {
@@ -95,7 +95,7 @@ export default class Heimdall implements JsonSerializable<Object> {
     session data for transfer. Heimdall-tree can load time
     data from this format or out of `getSessionData`.
    */
-  toJSON(): Object {
+  public toJSON(): object {
     return {
       heimdallVersion: VERSION,
       format,
@@ -105,7 +105,7 @@ export default class Heimdall implements JsonSerializable<Object> {
     };
   }
 
-  toString(): string {
+  public toString(): string {
     return JSON.stringify(this.toJSON());
   }
 }

--- a/src/runtime/session.ts
+++ b/src/runtime/session.ts
@@ -4,22 +4,22 @@ import EventArray from '../shared/event-array';
 import CounterStore from '../shared/counter-store';
 
 export default class HeimdallSession {
-  monitors: CounterStore;
-  configs: HashMap<any>;
-  events: EventArray;
+  public monitors: CounterStore;
+  public configs: HashMap<any>;
+  public events: EventArray;
 
   constructor() {
     this.init();
   }
 
-  init(): void {
+  public init(): void {
     this.monitors = new CounterStore();
     this.configs = new HashMap();
     this.events = new EventArray(640000 * 4);
   }
 
   // mostly for test helper purposes
-  reset(): void {
+  public reset(): void {
     this.monitors.clean();
     this.events.length = 0;
   }

--- a/src/shared/array-fill.ts
+++ b/src/shared/array-fill.ts
@@ -5,8 +5,8 @@ export default function fill(array: Uint32Array | number[], value: number, start
     return array.fill(value, start, end);
   } else {
     let s: number = start || 0;
-    let e: number = end || array.length;
-    for (;s<e;s++) {
+    const e: number = end || array.length;
+    for (; s < e; s++) {
       array[s] = value;
     }
     return array;

--- a/src/shared/array-grow.ts
+++ b/src/shared/array-grow.ts
@@ -3,7 +3,7 @@ import arrayFill from './array-fill';
 
 export default function grow(array: Uint32Array | number[], oldLength: number, newLength: number, fillValue = 0) {
   if (hasTypedArrays()) {
-    let ret = new Uint32Array(newLength);
+    const ret = new Uint32Array(newLength);
     ret.set(array);
 
     if (fillValue !== 0) {

--- a/src/shared/counter-store-options.ts
+++ b/src/shared/counter-store-options.ts
@@ -1,0 +1,20 @@
+const DEFAULT_STORE_SIZE: number = 1e3;
+const DEFAULT_NAMESPACE_SIZE: number = 10;
+
+/**
+ * Wrapper type around options for `CounterStore`.
+ *
+ * Intentionally left private as `CounterStore`
+ * only used internally when `HeimdallSession` is created.
+ *
+ * @class CounterStoreOptions
+ */
+export default class CounterStoreOptions {
+  public storeSize: number;
+  public namespaceAllocation: number;
+
+  constructor(storeSize: number = DEFAULT_STORE_SIZE, namespaceAllocation: number = DEFAULT_NAMESPACE_SIZE) {
+    this.storeSize = storeSize;
+    this.namespaceAllocation = namespaceAllocation;
+  }
+}

--- a/src/shared/event-array.ts
+++ b/src/shared/event-array.ts
@@ -7,17 +7,17 @@ export default class EventArray implements JsonSerializable<number[]> {
   private _length: number;
   private _data: any[];
 
-  length: number;
+  public length: number;
 
   constructor(length: number = SMALL_ARRAY_LENGTH, initialData?: any[]) {
     this.init(length, initialData);
   }
 
-  toJSON(): number[] {
+  public toJSON(): number[] {
     return this._data.slice(0, this.length);
   }
 
-  init(length: number = SMALL_ARRAY_LENGTH, initialData?: any[]): void {
+  public init(length: number = SMALL_ARRAY_LENGTH, initialData?: any[]): void {
     this.length = 0;
     this._length = length;
     this._data = new Array(length);
@@ -38,7 +38,7 @@ export default class EventArray implements JsonSerializable<number[]> {
 
   // TODO this should probably multiple index by 4 to hide
   // that we store in a flat array
-  get(index: number): any | undefined {
+  public get(index: number): any | undefined {
     if (index >= 0 && index < this.length) {
       return this._data.slice(index, index + 4);
     }
@@ -46,7 +46,7 @@ export default class EventArray implements JsonSerializable<number[]> {
     return undefined;
   }
 
-  set(index: number, value: any): void {
+  public set(index: number, value: any): void {
     if (index > this.length) {
       throw new Error("Index is out of array bounds.");
     }
@@ -58,14 +58,14 @@ export default class EventArray implements JsonSerializable<number[]> {
     this._data[index] = value;
   }
 
-  forEach(cb: Function): void {
+  public forEach(cb: (any, number) => void): void {
     for (let i = 0; i < this.length; i += 4) {
       cb(this._data.slice(i, i + 4), i);
     }
   }
 
-  push(op: number, name: string | number, time: number, data: Uint32Array | number[] | FastIntArray): number {
-    let index: number = this.length;
+  public push(op: number, name: string | number, time: number, data: Uint32Array | number[] | FastIntArray): number {
+    const index: number = this.length;
     this.length += 4;
 
     if (index >= this._length) {
@@ -81,8 +81,8 @@ export default class EventArray implements JsonSerializable<number[]> {
     return index;
   }
 
-  pop(): any | undefined {
-    let index: number = --this.length;
+  public pop(): any | undefined {
+    const index: number = --this.length;
 
     if (index < 0) {
       this.length = 0;

--- a/src/shared/fast-int-array.ts
+++ b/src/shared/fast-int-array.ts
@@ -10,14 +10,14 @@ export default class FastIntArray implements JsonSerializable<Uint32Array | numb
   private _fillValue: number;
   private _data: Uint32Array | number[];
 
-  length: number;
+  public length: number;
 
   constructor(length: number = SMALL_ARRAY_LENGTH, initialData?: Uint32Array | number[] | FastIntArray) {
     this.init(length, initialData);
   }
 
-  init(length: number = SMALL_ARRAY_LENGTH, initialData?: Uint32Array | number[] | FastIntArray): void {
-    let useTypedArray = hasTypedArrays();
+  public init(length: number = SMALL_ARRAY_LENGTH, initialData?: Uint32Array | number[] | FastIntArray): void {
+    const useTypedArray = hasTypedArrays();
     this.length = 0;
     this._length = length;
     this._fillValue = 0;
@@ -41,11 +41,11 @@ export default class FastIntArray implements JsonSerializable<Uint32Array | numb
     }
   }
 
-  toJSON(): Uint32Array | number[] {
+  public toJSON(): Uint32Array | number[] {
     return this._data.slice(0, this.length);
   }
 
-  get(index: number): number | undefined {
+  public get(index: number): number | undefined {
     if (index >= 0 && index < this.length) {
       return this._data[index];
     }
@@ -53,7 +53,7 @@ export default class FastIntArray implements JsonSerializable<Uint32Array | numb
     return undefined;
   }
 
-  increment(index: number): void {
+  public increment(index: number): void {
     this._data[index]++;
   }
 
@@ -62,20 +62,20 @@ export default class FastIntArray implements JsonSerializable<Uint32Array | numb
    enables us to efficiently increase the length by
    any quantity.
    */
-  grow(newLength: number): void {
+  public grow(newLength: number): void {
     this._data = arrayGrow(this._data, this._length, newLength, this._fillValue);
     this._length = newLength;
   }
 
-  claim(count: number): void {
+  public claim(count: number): void {
     this.length += count;
     while (this.length > this._length) {
       this.grow(this._length * 2);
     }
   }
 
-  push(int: number): void {
-    let index: number = this.length++;
+  public push(int: number): void {
+    const index: number = this.length++;
 
     if (index === this._length) {
       this.grow(this._length * 2);

--- a/src/shared/fill.ts
+++ b/src/shared/fill.ts
@@ -1,13 +1,16 @@
 import A from './a';
 
-export default function fill(array: Uint32Array | number[], value: number, start?: number, end?: number): Uint32Array | number[] {
+export default function fill(array: Uint32Array | number[],
+                             value: number,
+                             start?: number,
+                             end?: number): Uint32Array | number[] {
   if (typeof array.fill === 'function') {
     return array.fill(value, start, end);
   } else {
-    let len: number = array.length;
+    const len: number = array.length;
     let s: number = start || 0;
-    let e: number = end || len;
-    for (;s<e;s++) {
+    const e: number = end || len;
+    for (; s < e; s++) {
       array[s] = value;
     }
     return array;

--- a/src/shared/hash-map.ts
+++ b/src/shared/hash-map.ts
@@ -1,9 +1,9 @@
-export const UNDEFINED_KEY: Object = Object.create(null);
+export const UNDEFINED_KEY: object = Object.create(null);
 
 export default class HashMap<T> {
-  private _data: Object;
+  private _data: object;
 
-  data: Object;
+  public data: object;
 
   constructor(entries?: any) {
     this._data = Object.create(null);
@@ -15,8 +15,8 @@ export default class HashMap<T> {
     }
   }
 
-  forEach(cb: Function): HashMap<T> {
-    for (let key in this._data) {
+  public forEach(cb: (any, object) => void): HashMap<T> {
+    for (const key in this._data) {
       // skip undefined
       if (this._data[key] !== UNDEFINED_KEY) {
         cb(this._data[key], key);
@@ -26,23 +26,23 @@ export default class HashMap<T> {
     return this;
   }
 
-  has(key: string): boolean {
+  public has(key: string): boolean {
     return key in this._data && this._data[key] !== UNDEFINED_KEY;
   }
 
-  get(key: string): T | undefined {
-    let val: T = this._data[key];
+  public get(key: string): T | undefined {
+    const val: T = this._data[key];
 
     return val === UNDEFINED_KEY ? undefined : val;
   }
 
-  set(key: string | number, value: T): HashMap<T> {
+  public set(key: string | number, value: T): HashMap<T> {
     this._data[key] = value;
 
     return this;
   }
 
-  delete(key: string): void {
+  public delete(key: string): void {
     this._data[key] = UNDEFINED_KEY;
   }
 }

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -1,5 +1,5 @@
 const HAS_CONSOLE: boolean = typeof console !== 'undefined';
-const K: Function = function() {};
+const K: () => void = () => {};
 
 export const warn = HAS_CONSOLE ? function warn() {
   console.warn.apply(console, arguments);

--- a/src/shared/time.ts
+++ b/src/shared/time.ts
@@ -1,12 +1,12 @@
-export let now: number;
+export let now: () => number;
 export let format: string;
 export let ORIGIN_TIME: number;
 
 // It turns out to be nicer for perf to bind than to close over the time method
 // however, when testing we need to be able to stub the clock via the global
 // so we use this boolean to determine whether we "bind" or use a wrapper function.
-const freeGlobal = typeof window !== 'undefined' ? window : global;
-const IS_TESTING = freeGlobal.IS_HEIMDALL_TEST_ENVIRONMENT;
+const freeGlobal: any = typeof window !== 'undefined' ? window : global;
+const IS_TESTING: boolean = freeGlobal.IS_HEIMDALL_TEST_ENVIRONMENT;
 
 if (typeof performance === 'object' && typeof performance.now === 'function') {
   now = IS_TESTING ? function now() { return performance.now(); } : performance.now.bind(performance);

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,58 @@
 {
-  "extends": "tslint:latest"
+  "extends": "tslint:latest",
+  "rules": {
+    "interface-name": [true, "never-prefix"],
+    "forin": false,
+    "prefer-for-of": false,
+    "no-empty": false,
+    "arrow-parens": [true, "ban-single-arg-parens"],
+    "member-ordering": [true, {
+      "order": [
+        "private-static-field",
+        "private-static-method",
+        "private-instance-field",
+        "private-instance-method",
+        "private-constructor",
+        "protected-static-field",
+        "protected-static-method",
+        "protected-instance-field",
+        "protected-instance-method",
+        "protected-constructor",
+        "public-static-field",
+        "public-static-method",
+        "public-instance-field",
+        "public-constructor",
+        "public-instance-method"
+      ]
+    }],
+    "object-literal-sort-keys": false,
+    "no-bitwise": false,
+    "match-default-export-name": false,
+    "no-default-export": false,
+    "no-internal-module": true,
+    "ordered-imports": {
+      "options": {
+        "import-sources-order": "never",
+        "named-imports-order": "never"
+      }
+    },
+    "variable-name": {
+      "options": [
+        "ban-keywords",
+        "allow-pascal-case"
+      ]
+    },
+    "trailing-comma": {
+      "options": {
+        "multiline": "never",
+        "singleline": "never"
+      }
+    },
+    "quotemark": {
+      "options": [
+        "single",
+        "avoid-escape"
+      ]
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,18 +47,16 @@ benchmark@^2.0.0:
     lodash "^4.17.3"
     platform "^1.3.3"
 
-boxen@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/boxen/-/boxen-0.6.0.tgz#8364d4248ac34ff0ef1b2f2bf49a6c60ce0d81b6"
+boxen@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.0.0.tgz#b2694baf1f605f708ff0177c12193b22f29aaaab"
   dependencies:
     ansi-align "^1.1.0"
-    camelcase "^2.1.0"
+    camelcase "^4.0.0"
     chalk "^1.1.1"
     cli-boxes "^1.0.0"
-    filled-array "^1.0.0"
-    object-assign "^4.0.1"
-    repeating "^2.0.0"
-    string-width "^1.0.1"
+    string-width "^2.0.0"
+    term-size "^0.1.0"
     widest-line "^1.0.0"
 
 brace-expansion@^1.0.0:
@@ -74,17 +72,13 @@ browser-resolve@^1.11.0:
   dependencies:
     resolve "1.1.7"
 
-buffer-shims@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
-
 builtin-modules@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
-camelcase@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
+camelcase@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -153,19 +147,16 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-configstore@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/configstore/-/configstore-2.1.0.tgz#737a3a7036e9886102aa6099e47bb33ab1aba1a1"
+configstore@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.0.0.tgz#e1b8669c1803ccc50b545e92f8e6e79aa80e0196"
   dependencies:
-    dot-prop "^3.0.0"
+    dot-prop "^4.1.0"
     graceful-fs "^4.1.2"
     mkdirp "^0.5.0"
-    object-assign "^4.0.1"
-    os-tmpdir "^1.0.0"
-    osenv "^0.1.0"
-    uuid "^2.0.1"
+    unique-string "^1.0.0"
     write-file-atomic "^1.1.2"
-    xdg-basedir "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 console-browserify@1.1.x:
   version "1.1.0"
@@ -177,11 +168,22 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-create-error-class@^3.0.1:
+create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
   dependencies:
     capture-stack-trace "^1.0.0"
+
+cross-spawn-async@^2.1.1:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
+  dependencies:
+    lru-cache "^4.0.0"
+    which "^1.2.8"
+
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -245,17 +247,15 @@ domutils@1.5:
     dom-serializer "0"
     domelementtype "1"
 
-dot-prop@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
+dot-prop@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.1.1.tgz#a8493f0b7b5eeec82525b5c7587fa7de7ca859c1"
   dependencies:
     is-obj "^1.0.0"
 
-duplexer2@^0.1.4:
+duplexer3@^0.1.4:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
-  dependencies:
-    readable-stream "^2.0.2"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
 entities@1.0:
   version "1.0.0"
@@ -265,19 +265,9 @@ entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-error-ex@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.0.tgz#e67b43f3e82c96ea3a584ffee0b9fc3325d802d9"
-  dependencies:
-    is-arrayish "^0.2.1"
-
-escape-string-regexp@1.0.2:
+escape-string-regexp@1.0.2, escape-string-regexp@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
-
-escape-string-regexp@^1.0.2:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 estree-walker@^0.2.1:
   version "0.2.1"
@@ -287,13 +277,20 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+execa@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.4.0.tgz#4eb6467a36a095fabb2970ff9d5e3fb7bce6ebc3"
+  dependencies:
+    cross-spawn-async "^2.1.1"
+    is-stream "^1.1.0"
+    npm-run-path "^1.0.0"
+    object-assign "^4.0.1"
+    path-key "^1.0.0"
+    strip-eof "^1.0.0"
+
 exit@0.1.2, exit@0.1.x:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
-
-filled-array@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/filled-array/-/filled-array-1.1.0.tgz#c3c4f6c663b923459a9aa29912d2d031f1507f84"
 
 findup-sync@~0.3.0:
   version "0.3.0"
@@ -304,6 +301,10 @@ findup-sync@~0.3.0:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 glob@3.2.11, "glob@~ 3.2.1":
   version "3.2.11"
@@ -333,24 +334,20 @@ glob@~5.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-got@^5.0.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/got/-/got-5.7.1.tgz#5f81635a61e4a6589f180569ea4e381680a51f35"
+got@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
   dependencies:
-    create-error-class "^3.0.1"
-    duplexer2 "^0.1.4"
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
     is-redirect "^1.0.0"
     is-retry-allowed "^1.0.0"
     is-stream "^1.0.0"
     lowercase-keys "^1.0.0"
-    node-status-codes "^1.0.0"
-    object-assign "^4.0.1"
-    parse-json "^2.1.0"
-    pinkie-promise "^2.0.0"
-    read-all-stream "^3.0.0"
-    readable-stream "^2.0.5"
-    timed-out "^3.0.0"
-    unzip-response "^1.0.2"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
@@ -396,21 +393,15 @@ ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
-is-arrayish@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
-
-is-finite@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
-  dependencies:
-    number-is-nan "^1.0.0"
-
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
   dependencies:
     number-is-nan "^1.0.0"
+
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
 is-npm@^1.0.0:
   version "1.0.0"
@@ -428,7 +419,7 @@ is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
-is-stream@^1.0.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -436,9 +427,9 @@ isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
-isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 jade@0.26.3:
   version "0.26.3"
@@ -464,15 +455,15 @@ jshint@~2.8.0:
     shelljs "0.3.x"
     strip-json-comments "1.0.x"
 
-latest-version@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-2.0.0.tgz#56f8d6139620847b8017f8f1f4d78e211324168b"
+latest-version@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
   dependencies:
-    package-json "^2.0.0"
+    package-json "^4.0.0"
 
-lazy-req@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/lazy-req/-/lazy-req-1.1.0.tgz#bdaebead30f8d824039ce0ce149d4daa07ba1fac"
+lazy-req@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lazy-req/-/lazy-req-2.0.0.tgz#c9450a363ecdda2e6f0c70132ad4f37f8f06f2b4"
 
 lodash@3.7.x:
   version "3.7.0"
@@ -489,6 +480,13 @@ lowercase-keys@^1.0.0:
 lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
+
+lru-cache@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
+  dependencies:
+    pseudomap "^1.0.1"
+    yallist "^2.0.0"
 
 magic-string@^0.15.2:
   version "0.15.2"
@@ -521,17 +519,13 @@ minimatch@3.0.0:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.3.0:
   version "0.3.0"
@@ -571,9 +565,11 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
-node-status-codes@^1.0.0:
+npm-run-path@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
+  dependencies:
+    path-key "^1.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -596,53 +592,26 @@ optimist@~0.6.0:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-os-homedir@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-
-os-tmpdir@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-
-osenv@^0.1.0:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
+package-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.0.tgz#f3c9dc8738f5b59304d54d2cfb3f91d08fdd7998"
   dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.0"
-
-package-json@^2.0.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/package-json/-/package-json-2.4.0.tgz#0d15bd67d1cbbddbb2ca222ff2edb86bcb31a8bb"
-  dependencies:
-    got "^5.0.0"
+    got "^6.7.1"
     registry-auth-token "^3.0.1"
     registry-url "^3.0.3"
     semver "^5.1.0"
-
-parse-json@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
-  dependencies:
-    error-ex "^1.2.0"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-key@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
+
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
-
-pinkie-promise@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
-  dependencies:
-    pinkie "^2.0.0"
-
-pinkie@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
 platform@^1.3.3:
   version "1.3.3"
@@ -652,9 +621,9 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+pseudomap@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 rc@^1.0.1, rc@^1.1.6:
   version "1.1.7"
@@ -665,13 +634,6 @@ rc@^1.0.1, rc@^1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-read-all-stream@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/read-all-stream/-/read-all-stream-3.1.0.tgz#35c3e177f2078ef789ee4bfafa4373074eaef4fa"
-  dependencies:
-    pinkie-promise "^2.0.0"
-    readable-stream "^2.0.0"
-
 readable-stream@1.1:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.13.tgz#f6eef764f514c89e2b9e23146a75ba106756d23e"
@@ -680,18 +642,6 @@ readable-stream@1.1:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
-
-readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz#9cf49463985df016c8ae8813097a9293a9b33729"
-  dependencies:
-    buffer-shims "^1.0.0"
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
 
 registry-auth-token@^3.0.1:
   version "3.1.0"
@@ -704,12 +654,6 @@ registry-url@^3.0.3:
   resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
   dependencies:
     rc "^1.0.1"
-
-repeating@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
-  dependencies:
-    is-finite "^1.0.0"
 
 resolve@1.1.7:
   version "1.1.7"
@@ -774,6 +718,10 @@ rsvp@~3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.2.1.tgz#07cb4a5df25add9e826ebc67dcc9fd89db27d84a"
 
+safe-buffer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
 semver-diff@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
@@ -818,6 +766,13 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
+string-width@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^3.0.0"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -827,6 +782,10 @@ strip-ansi@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
 strip-json-comments@1.0.x:
   version "1.0.4"
@@ -844,9 +803,15 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-timed-out@^3.0.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-3.1.3.tgz#95860bfcc5c76c277f8f8326fd0f5b2e20eba217"
+term-size@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-0.1.1.tgz#87360b96396cab5760963714cda0d0cbeecad9ca"
+  dependencies:
+    execa "^0.4.0"
+
+timed-out@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
 tippex@^2.1.1:
   version "2.3.1"
@@ -856,9 +821,9 @@ to-iso-string@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
 
-tslint@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-4.4.2.tgz#b14cb79ae039c72471ab4c2627226b940dda19c6"
+tslint@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-4.5.1.tgz#05356871bef23a434906734006fc188336ba824b"
   dependencies:
     babel-code-frame "^6.20.0"
     colors "^1.1.2"
@@ -867,7 +832,12 @@ tslint@^4.4.2:
     glob "^7.1.1"
     optimist "~0.6.0"
     resolve "^1.1.7"
-    update-notifier "^1.0.2"
+    tsutils "^1.1.0"
+    update-notifier "^2.0.0"
+
+tsutils@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.4.0.tgz#84f8a83df9967d35bf1ff3aa48c7339593d64e19"
 
 type-detect@0.1.1:
   version "0.1.1"
@@ -881,30 +851,36 @@ typescript@^1.8.9:
   version "1.8.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-1.8.10.tgz#b475d6e0dff0bf50f296e5ca6ef9fbb5c7320f1e"
 
-typescript@^2.2:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"
+typescript@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
 
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
 
-unzip-response@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
-
-update-notifier@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-1.0.3.tgz#8f92c515482bd6831b7c93013e70f87552c7cf5a"
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
   dependencies:
-    boxen "^0.6.0"
+    crypto-random-string "^1.0.0"
+
+unzip-response@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+
+update-notifier@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.1.0.tgz#ec0c1e53536b76647a24b77cb83966d9315123d9"
+  dependencies:
+    boxen "^1.0.0"
     chalk "^1.0.0"
-    configstore "^2.0.0"
+    configstore "^3.0.0"
     is-npm "^1.0.0"
-    latest-version "^2.0.0"
-    lazy-req "^1.1.0"
+    latest-version "^3.0.0"
+    lazy-req "^2.0.0"
     semver-diff "^2.0.0"
-    xdg-basedir "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"
@@ -912,17 +888,15 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
-util-deprecate@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-uuid@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-
 vlq@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.1.tgz#14439d711891e682535467f8587c5630e4222a6c"
+
+which@^1.2.8:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  dependencies:
+    isexe "^2.0.0"
 
 widest-line@^1.0.0:
   version "1.0.0"
@@ -946,8 +920,10 @@ write-file-atomic@^1.1.2:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
-xdg-basedir@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-2.0.0.tgz#edbc903cc385fc04523d966a335504b5504d1bd2"
-  dependencies:
-    os-homedir "^1.0.0"
+xdg-basedir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
+
+yallist@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"


### PR DESCRIPTION
### Summary

We recently converted the project to TypeScript, see [here](https://github.com/heimdalljs/heimdalljs-lib/pull/79).  `tslint` was added as one of the dependencies to make sure our code looks the same over time. It also includes type checks to avoid penalties during runtime.

`tslint` wasn't running as a part of our `test` command and we had quite a bit of `tslint` warnings. This change aims to fix them.

### Details

+ bumps both `tslint` and `typescript` to the latest version
+ adds `tslint.json` with project specific rules, see [tslint rules](https://palantir.github.io/tslint/rules/); *side note*: happy to bikeshed the rules because, you know, opinions 😃
+ adds `tslint:format` command so contributors don't have to hunt down inconsistencies in the code and can just run `yarn run tslint:format`
+ makes `tslint` check a part of our `test` command

**P.S.** It's a fairly big PR. If you guys prefer to make it smaller so it's easier to review I can make that happen.
