### PR TITLE
Change unbalanced start/stop to warn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,14 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
-  - "5"
+  - "6"
   - "node"
-sudo: false
 
-cache:
-  directories:
-    $HOME/.npm
-
+cache: yarn
 before_install:
-  # prevent the npm loading indicator
-  - npm config --global set spin false
-  # if npm version is less 3.0.0 (lets say 1.x or 2.x) we should attempt to upgrade to 3
-  - if [[ $(npm -v | cut -d '.' -f 1) -lt 3 ]]; then npm i -g npm@^3; fi
-
-install:
-  - npm install --no-optional
+  - nvm install 7
+  - nvm use 7
+before_script:
+  - yarn run build:node
+  - yarn run build:test
+  - nvm use $TRAVIS_NODE_VERSION

--- a/src/cookie.js
+++ b/src/cookie.js
@@ -14,9 +14,11 @@ export default class Cookie {
     let monitor;
 
     if (this._heimdall.current !== this._node) {
-      throw new TypeError('cannot stop: not the current node');
+      console.log(`Cannot stop: not the current node.`);
+      return;
     } else if (this.stopped === true) {
-      throw new TypeError('cannot stop: already stopped');
+      console.log(`Cannot stop: already stopped.`);
+      return;
     }
 
     this._stopped = true;
@@ -26,7 +28,8 @@ export default class Cookie {
 
   resume() {
     if (this._stopped === false) {
-      throw new TypeError('cannot resume: not stopped');
+      console.log(`Cannot resume: not stopped.`);
+      return;
     }
 
     this._stopped = false;


### PR DESCRIPTION
Start/stop can easily become unbalanced in error cases, when
instrumentation information is much less useful.  Throwing errors here
mainly has the effect of masking the real error.