### PR TITLE
patch 0.3 to support all of v2's API surface area

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.ts]
+indent_style = space
+indent_size = 2
+
+[*.css]
+indent_style = space
+indent_size = 2
+
+[*.html]
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/src/runtime/deprecated-cookie.ts
+++ b/src/runtime/deprecated-cookie.ts
@@ -1,0 +1,82 @@
+import deprecate from '../shared/deprecate';
+import Heimdall from './index';
+
+const COOKIE_DEPRECATION_MSG = `Using the return of heimdall.start() is deprecated. All operations (start/resume/annotate etc.) should be done via the heimdall instance.`;
+const COOKIE_DEPRECATION_OPTS = { id: 'Heimdall.cookie', since: '0.3', until: '0.4' };
+
+export default class DeprecatedCookie extends Number {
+  private __node: any;
+  private __resumeNode: any;
+  private _value: Number;
+  private __heimdall: Heimdall;
+  private __stopped: Boolean;
+
+  constructor(value, node, heimdall) {
+    super(value);
+    this._value = value;
+    this.__node = node;
+    this.__resumeNode = null;
+    this.__heimdall = heimdall;
+    this.__stopped = false;
+  }
+
+  stop() {
+    deprecate(COOKIE_DEPRECATION_MSG, COOKIE_DEPRECATION_OPTS);
+    deprecate('cookie.stop', "HeimdallCookie has been deprecated. Refactor:" +
+      "\n```\nlet cookie = heimdall.start(<string>); cookie.stop();```\n" +
+      "\nto:\n```let token = heimdall.start(<string>); heimdall.stop(token);```");
+
+    this.__heimdall.stop(this._value);
+  }
+
+  resume() {
+    deprecate(COOKIE_DEPRECATION_MSG, COOKIE_DEPRECATION_OPTS);
+    deprecate('cookie.resume', "HeimdallCookie has been deprecated. Refactor:" +
+      "\n```\nlet cookie = heimdall.start(<string>); cookie.resume();```\n" +
+      "\nto:\n```let token = heimdall.start(<string>); heimdall.resume(token);```");
+
+    this.__heimdall.resume(this._value);
+  }
+
+  get _node() {
+    deprecate(COOKIE_DEPRECATION_MSG, COOKIE_DEPRECATION_OPTS);
+
+    return this.__node;
+  }
+
+  get _resumeNode() {
+    deprecate(COOKIE_DEPRECATION_MSG, COOKIE_DEPRECATION_OPTS);
+
+    return this.__resumeNode;
+  }
+
+  get _heimdall() {
+    deprecate(COOKIE_DEPRECATION_MSG, COOKIE_DEPRECATION_OPTS);
+
+    return this.__heimdall;
+  }
+
+  get _stopped() {
+    deprecate(COOKIE_DEPRECATION_MSG, COOKIE_DEPRECATION_OPTS);
+
+    return this.__stopped;
+  }
+
+  get stats() {
+    deprecate(COOKIE_DEPRECATION_MSG, COOKIE_DEPRECATION_OPTS);
+
+    return this._node.stats.own;
+  }
+
+  valueOf() {
+    return this._value;
+  }
+
+  toString() {
+    return `${this._value}`;
+  }
+
+  toJSON() {
+    return this.toString();
+  }
+}

--- a/src/runtime/deprecated-node.ts
+++ b/src/runtime/deprecated-node.ts
@@ -1,0 +1,105 @@
+import Heimdall from './index';
+import deprecate from '../shared/deprecate';
+
+export default class DeprecatedNode {
+  private _heimdall: Heimdall;
+  private _id: any;
+
+  constructor(token, heimdall, id, data) {
+    this._heimdall = heimdall;
+
+    this._id = token;
+    this.id = id;
+
+    if (id === '' || typeof id !== 'string') {
+      deprecate(`non-string-id`, {
+        id: 'non-string-id',
+        since: '0.3',
+        until: '0.4'
+      });
+
+      if (!id || id.name === '' || typeof id.name !== 'string') {
+        throw new TypeError('HeimdallNode#id.name must be a string');
+      }
+
+      this.id = id.name;
+      heimdall.annotate({ 'heimdall-node-id': id });
+    }
+
+    // TODO we need to make this a counter primitive
+    // TODO this would also fail if we segmented the data
+    this.stats = data;
+    heimdall.annotate({ 'heimdall-node-stats': data });
+
+    // this._children = [];
+    // this.parent = null;
+  }
+
+  get isRoot() {
+    throw new Error('removed');
+  }
+
+  visitPreOrder() {
+    throw new Error('removed');
+  }
+
+  visitPostOrder() {
+    throw new Error('removed');
+  }
+
+  forEachChild() {
+    throw new Error('removed');
+  }
+
+  remove() {
+    throw new Error('Shim Needs Implemented');
+    /*
+    if (!this.parent) {
+      throw new Error('Cannot remove the root heimdalljs node.');
+    }
+    if (this._heimdall.current === this) {
+      throw new Error('Cannot remove an active heimdalljs node.');
+    }
+
+    return this.parent.removeChild(this);
+    */
+  }
+
+  toJSON() {
+    throw new Error('removed');
+  }
+
+  toJSONSubgraph() {
+    throw new Error('removed');
+  }
+
+  addChild(node) {
+    throw new Error('Shim Needs Implemented');
+    /*
+    if (node.parent) {
+      throw new TypeError('Node ' + node._id + ' already has a parent.  Cannot add to ' + this._id);
+    }
+
+    this._children.push(node);
+
+    node.parent = this;
+    */
+  }
+
+
+  removeChild(child) {
+    throw new Error('Shim Needs Implemented');
+    /*
+    let index = this._children.indexOf(child);
+
+    if (index < 0) {
+      throw new Error('Child(' + child._id + ') not found in Parent(' + this._id + ').  Something is very wrong.');
+    }
+    this._children.splice(index, 1);
+
+    child.parent = null;
+
+    return child;
+    */
+  }
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,0 +1,134 @@
+import Session from './session';
+import now from '../shared/time';
+import { format } from '../shared/time';
+import CounterStore from '../shared/counter-store';
+import EventArray from '../shared/event-array';
+import FastIntArray from '../shared/fast-int-array';
+import { NULL_NUMBER } from '../shared/counter-store';
+import OpCodes from '../shared/op-codes';
+import JsonSerializable from '../interfaces/json-serializable';
+import DeprecatedCookie from './deprecated-cookie';
+import deprecate from '../shared/deprecate';
+
+const VERSION = 'VERSION_STRING_PLACEHOLDER';
+
+class DeprecatedNode {
+  constructor() {
+
+  }
+
+  get stats() {
+
+  }
+}
+
+export default class Heimdall implements JsonSerializable<Object> {
+  private _session: Session;
+
+  static get VERSION(): string {
+    return VERSION;
+  }
+
+  constructor(session) {
+    if (arguments.length < 1) {
+      this._session = new Session();
+      this.start('session-root');
+    } else {
+      this._session = session;
+    }
+  }
+
+  get VERSION(): string {
+    return VERSION;
+  }
+
+  get _monitors(): CounterStore {
+    return this._session.monitors;
+  }
+
+  get _events(): EventArray {
+    return this._session.events;
+  }
+
+  _retrieveCounters(): Uint32Array | number[] | FastIntArray {
+    return this._monitors.cache();
+  }
+
+  start(name: string): number {
+    let token = this._session.events.push(OpCodes.OP_START, name, now(), this._retrieveCounters());
+    return new DeprecatedCookie(token, this);
+  }
+
+  stop(token: number): void {
+    this._session.events.push(OpCodes.OP_STOP, token.valueOf(), now(), this._retrieveCounters());
+  }
+
+  resume(token: number): void {
+    this._session.events.push(OpCodes.OP_RESUME, token.valueOf(), now(), this._retrieveCounters());
+  }
+
+  removeNode() {
+    // TODO make this notice better and make it actually segment data
+    deprecate(`removeNode dont remove bro`, { id: 'remove-node', since: '0.3', until: '0.4'});
+    throw new Error('Not Implemented!');
+  }
+
+  statsFor(name) {
+    return this._monitors.getNamespace(name);
+  }
+
+  annotate(info: Uint32Array | number[] | FastIntArray): void {
+    // This has the side effect of making events heterogenous, as info is an object
+    // while counters will always be `null` or an `Array`
+    this._session.events.push(OpCodes.OP_ANNOTATE, NULL_NUMBER, NULL_NUMBER, info);
+  }
+
+  hasMonitor(name): boolean {
+    return !!this._monitors.has(name);
+  }
+
+  registerMonitor(name: string, ...keys: string[]): never | Object {
+    if (name === 'own' || name === 'time') {
+      throw new Error('Cannot register monitor at namespace "' + name + '".  "own" and "time" are reserved');
+    }
+    if (this.hasMonitor(name)) {
+      throw new Error('A monitor for "' + name + '" is already registered"');
+    }
+
+    return this._monitors.registerNamespace(name, keys)
+  }
+
+  increment(token: number): void {
+    this._session.monitors.increment(token);
+  }
+
+  configFor(name: string): any {
+    let config = this._session.configs.get(name);
+
+    if (!config) {
+      config = Object.create(null);
+      this._session.configs.set(name, config);
+    }
+
+    return config;
+  }
+
+  /*
+    Ideally, this method should only be used for serializing
+    session data for transfer. Heimdall-tree can load time
+    data from this format or out of `getSessionData`.
+   */
+  toJSON(): Object {
+    return {
+      heimdallVersion: VERSION,
+      format,
+      monitors: this._monitors.toJSON(),
+      events: this._events.toJSON(),
+      serializationTime: now()
+    };
+  }
+
+  toString(): string {
+    return JSON.stringify(this.toJSON());
+  }
+}

--- a/src/shared/assert.ts
+++ b/src/shared/assert.ts
@@ -1,0 +1,5 @@
+export default function assert(msg: String, test: any) {
+  if (!test) {
+    throw new Error(msg);
+  }
+}

--- a/src/shared/deprecate.ts
+++ b/src/shared/deprecate.ts
@@ -1,0 +1,18 @@
+import assert from './assert';
+
+const DEPRECATIONS = Object.create(null);
+
+export default function deprecate(message: String, options) {
+  assert(`You must include a message as the first argument to deprecate`, message);
+  assert(`You must pass an options hash as the second argument to deprecate`, options);
+  assert(`You must include an 'id' in the options hash passed to deprecate`, options.id);
+  assert(`You must include 'since' in the options hash passed to deprecate`, options.since);
+  assert(`You must include 'until' in the options hash passed to deprecate`, options.until);
+  if (DEPRECATIONS[options.id]) {
+    return;
+  }
+
+  DEPRECATIONS[options.id] = true;
+
+  console.warn(`DEPRECATION[heimdalljs-${options.id}]: ${message}\nDeprecated in '${options.since}' and will be removed in '${options.until}'`);
+}


### PR DESCRIPTION
with deprecations

Unresolved Differences
To support node.remove, we'll need to do something like this: https://github.com/heimdalljs/heimdalljs-lib/blob/master/src/heimdall-tree/index.ts#L75
And/Or finish off the concept of streamable stats (tokens just can't be array index based only) in order to support a similar feature in-lieu of precise support.

heimdall.node() still needs implemented. This convenience wrapper may not belong in the lib anymore, if not it will need to be deprecated.

HeimdallTree should be updated to output a v2 compatible version of the graph for tooling (for now).

support has been added for heimdall.start(id: Object, schema: Function). Object IDs were converted to annotations. The inline/local schemas were also converted to annotations, but since these represent local "counter" data, we may want a specialized counter-store just for them. This is tricky because unlike monitors, these counts might segment but should not ever be snapshotted / incremented outside of the bounds of the node's start/stop. With the advantages that monitors come with, we may not want to keep a formal primitive around this in favor of users using ad-hoc annotations if needed.

Continuation of #82