### PR TITLE
fs-monitor: Skip shadowing getter-only properties in `fs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: 
+        os:
           - ubuntu-latest #later: windows-latest, macos-latest
-        node-version: 
-          - 20 # later: 22, 24
+        node-version:
+          - 20
+          - 24
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/heimdall-fs-monitor/index.js
+++ b/packages/heimdall-fs-monitor/index.js
@@ -144,13 +144,22 @@ class FSMonitor {
   _attach() {
     for (let member in fs) {
       if (this.blacklist.indexOf(member) === -1) {
-        let old = fs[member];
-        if (typeof old === 'function') {
-          let monitored = this._attachMember(fs, member, old);
+        continue;
+      }
 
-          if ('native' in old) {
-            this._attachMember(monitored, 'native', old, `${member}.native`);
-          }
+      const descriptor = Object.getOwnPropertyDescriptor(fs, member);
+
+      if (descriptor && descriptor.get && !descriptor.set) {
+        // Skip getter-only properties (like Utf8Stream, F_OK, etc. in Node.js 24+)
+        continue;
+      }
+
+      let old = fs[member];
+      if (typeof old === 'function') {
+        let monitored = this._attachMember(fs, member, old);
+
+        if ('native' in old) {
+          this._attachMember(monitored, 'native', old, `${member}.native`);
         }
       }
     }


### PR DESCRIPTION
To be merged after #158 